### PR TITLE
Remediate zizmor audit findings in CI workflows

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -16,15 +16,16 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Set up Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -59,6 +60,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,15 @@ on:
   #   branches: [ main ]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -34,8 +36,12 @@ jobs:
   scrape-stars:
     needs: test
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -69,8 +75,11 @@ jobs:
       run: python scrape_stars.py
 
     - name: Commit and push if changes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config --global user.name 'GitHub Action'
         git config --global user.email 'action@github.com'
+        git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}"
         git add github_stars.json
         git diff --quiet && git diff --staged --quiet || (git commit -m "Update GitHub stars data" && git push)

--- a/.github/workflows/update_star_lists.yml
+++ b/.github/workflows/update_star_lists.yml
@@ -6,13 +6,17 @@ on:
   workflow_dispatch:  # Allow manual triggering
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update-star-lists:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -34,8 +38,11 @@ jobs:
         python update_star_lists.py
 
     - name: Commit and push if changes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config --global user.name 'GitHub Action'
         git config --global user.email 'action@github.com'
+        git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}"
         git add github_stars.json
         git diff --quiet && git diff --staged --quiet || (git commit -m "Update star lists data" && git push)


### PR DESCRIPTION
## Summary
- **artipacked**: Add `persist-credentials: false` to all `actions/checkout` steps; configure explicit token-based remote URL for `git push` steps
- **excessive-permissions**: Move `pages: write`, `id-token: write`, and `contents: write` from workflow level to only the jobs that need them
- **dangerous-triggers**: Guard `workflow_run`-triggered build with `github.event.workflow_run.conclusion == 'success'` check

## Test plan
- [ ] Manually trigger each workflow via `workflow_dispatch` and verify they complete successfully
- [ ] Verify the deploy workflow skips when an upstream workflow fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)