### PR TITLE
Fix horizontal overflow on mobile viewports

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,12 +32,13 @@
   }
 
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif; background: var(--color-bg); color: var(--color-text); line-height: 1.5; }
+  html { overflow-x: hidden; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif; background: var(--color-bg); color: var(--color-text); line-height: 1.5; overflow-x: hidden; word-break: break-word; }
   a { color: var(--color-link); text-decoration: none; }
   a:hover { text-decoration: underline; }
 
   /* Layout */
-  .container { max-width: 768px; margin: 0 auto; padding: 0 1rem; }
+  .container { max-width: 768px; margin: 0 auto; padding: 0 1rem; overflow: hidden; }
 
   /* Profile header */
   .profile-header { display: flex; align-items: center; gap: 1rem; padding: 1.5rem 0; border-bottom: 1px solid var(--color-bg-tertiary); margin-bottom: 1rem; cursor: pointer; text-decoration: none; color: inherit; }
@@ -121,7 +122,7 @@
   .repo-detail { font-size: var(--font-sm); margin-top: .5rem; }
   .repo-detail dl { display: grid; grid-template-columns: auto 1fr; gap: .25rem .75rem; margin-top: .5rem; }
   .repo-detail dt { color: var(--color-text-muted); }
-  .repo-detail dd { color: var(--color-text-secondary); overflow-wrap: break-word; }
+  .repo-detail dd { color: var(--color-text-secondary); overflow-wrap: break-word; min-width: 0; }
   .repo-detail dd a { color: var(--color-link); }
   .lists-tags { margin-top: .5rem; }
   .lists-tags span {
@@ -130,7 +131,7 @@
   }
 
   /* Constellation chart */
-  .chart-container { margin-bottom: 1.5rem; border: 1px solid var(--color-border); border-radius: var(--radius); overflow: hidden; background: var(--color-bg-secondary); }
+  .chart-container { margin-bottom: 1.5rem; border: 1px solid var(--color-border); border-radius: var(--radius); overflow: hidden; background: var(--color-bg-secondary); max-width: 100%; }
   .chart-container svg { display: block; }
   .chart-legend { display: flex; flex-wrap: wrap; gap: .375rem .75rem; padding: .5rem .75rem; border-top: 1px solid var(--color-border); }
   .chart-legend span { display: inline-flex; align-items: center; gap: 4px; font-size: var(--font-sm); color: var(--color-text-muted); cursor: pointer; }


### PR DESCRIPTION
Prevent unwanted horizontal scrolling by constraining overflow on html/body/container, enabling word-break for long strings, and fixing grid cell min-width in repo details.