### PR TITLE
Restructure workflows: sync-stars orchestrator with workflow_call chain

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -1,26 +1,14 @@
 name: Deploy to GitHub Pages
-# workflow_run is guarded by checking workflow_run.conclusion == 'success' before any job runs
+
 on:
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - 'src/**'
-  #     - '*.json'
-  #     - '.github/workflows/deploy.yml'
+  workflow_call:
   workflow_dispatch:
-  workflow_run: # zizmor: ignore[dangerous-triggers]
-    types: [completed]
-    workflows:
-      - Scrape GitHub Stars
-      - Update Star Lists
 
 permissions:
   contents: read
 
 jobs:
   build:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository

--- a/.github/workflows/scrape-stars.yml
+++ b/.github/workflows/scrape-stars.yml
@@ -1,13 +1,8 @@
 name: Scrape GitHub Stars
 
 on:
-  # schedule:
-  #   - cron: '0 0 * * *'  # Run daily at midnight UTC
-  workflow_dispatch:  # Allow manual triggering
-  # push:
-  #   branches: [ main ]
-  # pull_request:
-  #   branches: [ main ]
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/sync-stars.yml
+++ b/.github/workflows/sync-stars.yml
@@ -1,0 +1,28 @@
+name: Sync Stars
+
+on:
+  schedule:
+    - cron: '17 3 * * *'  # Run daily at 3:17 AM UTC
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scrape:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/scrape-stars.yml
+
+  update-lists:
+    needs: scrape
+    permissions:
+      contents: write
+    uses: ./.github/workflows/update_star_lists.yml
+
+  deploy:
+    needs: update-lists
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/deploy-to-gh-pages.yml

--- a/.github/workflows/update_star_lists.yml
+++ b/.github/workflows/update_star_lists.yml
@@ -1,9 +1,8 @@
 name: Update Star Lists
 
 on:
-  # schedule:
-  #   - cron: '0 1 * * *'  # Run daily at 1 AM UTC
-  workflow_dispatch:  # Allow manual triggering
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Renames `main.yml` → `scrape-stars.yml` (via `git mv`) to match the naming convention of `update_star_lists.yml`
- Adds `sync-stars.yml` orchestrator: runs on cron (3:17 AM UTC) or `workflow_dispatch`, calls scrape → lists → deploy sequentially
- Replaces `workflow_run` triggers with `workflow_call` throughout — passes zizmor clean with no `ignore` suppressions
- Single deploy at the end of the pipeline; live site is never updated mid-sync

## Architecture

```
sync-stars.yml (cron / workflow_dispatch)
  └─ scrape-stars.yml      (workflow_call)  contents: write
  └─ update_star_lists.yml (workflow_call)  contents: write
  └─ deploy-to-gh-pages.yml (workflow_call) pages: write, id-token: write
```

Individual workflows remain independently triggerable via `workflow_dispatch` for debugging or reruns — they don't call deploy, so a solo run won't publish a half-updated site.

## Security

`workflow_run` was flagged by zizmor as a dangerous trigger (runs in base branch context, can access secrets even when triggered by fork PRs). `workflow_call` is the recommended replacement — the call chain is explicit, trust boundaries are clear, and permissions are scoped per-job in `sync-stars.yml`.

## Test plan

- [ ] Trigger `sync-stars.yml` manually and verify scrape → lists → deploy runs in sequence
- [ ] Trigger `scrape-stars.yml` independently and verify it completes without deploying
- [ ] Trigger `deploy-to-gh-pages.yml` independently via `workflow_dispatch` and verify it deploys
- [ ] Run zizmor: `podman run --rm -v "$(pwd)/.github:/github:ro" ghcr.io/woodruffw/zizmor:latest /github/workflows/*.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)