### PR TITLE
Resolve all zizmor auditor findings

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -7,8 +7,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    name: Build site artifact
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
@@ -29,11 +34,12 @@ jobs:
         path: ./_site
 
   deploy:
+    name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-24.04
     permissions:
-      pages: write
-      id-token: write
+      pages: write # deploy to GitHub Pages
+      id-token: write # verify deployment origin (OIDC)
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/scrape-stars.yml
+++ b/.github/workflows/scrape-stars.yml
@@ -7,8 +7,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   test:
+    name: Run tests
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -27,10 +32,11 @@ jobs:
       run: uv run pytest tests/test_scrape.py
 
   scrape-stars:
+    name: Scrape starred repositories
     needs: test
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
+      contents: write # commit updated github_stars.json
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -44,21 +50,6 @@ jobs:
     - name: Install dependencies
       run: uv sync
 
-    - name: Debug information
-      run: |
-        echo "Current directory: $(pwd)"
-        echo "Repository: ${{ github.repository }}"
-        echo "Repository owner: ${{ github.repository_owner }}"
-        git remote -v
-        git config --get remote.origin.url
-
-    - name: Check GitHub token
-      run: |
-        if [ -z "${{ secrets.GITHUB_TOKEN }}" ]; then
-          echo "GITHUB_TOKEN is not set in the repository secrets."
-          exit 1
-        fi
-
     - name: Run star scraper
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -71,6 +62,6 @@ jobs:
       run: |
         git config --global user.name 'GitHub Action'
         git config --global user.email 'action@github.com'
-        git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}"
+        git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
         git add github_stars.json
         git diff --quiet && git diff --staged --quiet || (git commit -m "Update GitHub stars data" && git push)

--- a/.github/workflows/sync-stars.yml
+++ b/.github/workflows/sync-stars.yml
@@ -7,22 +7,26 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   scrape:
     permissions:
-      contents: write
+      contents: write # commit updated github_stars.json
     uses: ./.github/workflows/scrape-stars.yml
 
   update-lists:
     needs: scrape
     permissions:
-      contents: write
+      contents: write # commit updated github_stars.json
     uses: ./.github/workflows/update_star_lists.yml
 
   deploy:
     needs: update-lists
     permissions:
-      contents: read
-      pages: write
-      id-token: write
+      contents: read # read site files for Pages build
+      pages: write # deploy to GitHub Pages
+      id-token: write # verify deployment origin (OIDC)
     uses: ./.github/workflows/deploy-to-gh-pages.yml

--- a/.github/workflows/update_star_lists.yml
+++ b/.github/workflows/update_star_lists.yml
@@ -7,11 +7,16 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   update-star-lists:
+    name: Update star lists
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
+      contents: write # commit updated github_stars.json
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -31,7 +36,7 @@ jobs:
       run: |
         git config --global user.name 'GitHub Action'
         git config --global user.email 'action@github.com'
-        git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}"
+        git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
         git pull --rebase origin master
 
     - name: Run star lists update script
@@ -40,7 +45,7 @@ jobs:
         GITHUB_USERNAME: ${{ github.repository_owner }}
       run: |
         echo "GITHUB_USERNAME: $GITHUB_USERNAME"
-        echo "GITHUB_TOKEN is set: ${{ secrets.GITHUB_TOKEN != '' }}"
+        echo "GITHUB_TOKEN is set: $([ -n "$GITHUB_TOKEN" ] && echo true || echo false)"
         uv run python scripts/update_star_lists.py
 
     - name: Commit and push if changes


### PR DESCRIPTION
## Summary

- **Template injection:** Remove inherited upstream debug scaffolding from `scrape-stars.yml`; replace `${{ github.repository }}` with `$GITHUB_REPOSITORY` env var in git remote URLs; replace inline secrets check with shell variable check
- **Concurrency limits:** Add workflow-level concurrency groups to all 4 workflows (`cancel-in-progress: true` for deploy, `false` for data-committing workflows)
- **Undocumented permissions:** Add explanatory comments to all permission grants
- **Anonymous definitions:** Add `name:` to all jobs

Resolves all 22 findings (5 info, 17 low) with no ignore suppressions — verified clean via `podman run --rm -v "$(pwd):/repo:ro" ghcr.io/zizmorcore/zizmor --persona auditor /repo/.github/workflows/`

## Test plan

- [x] zizmor `--persona auditor` returns 0 findings
- [ ] Trigger `sync-stars.yml` via `workflow_dispatch` and verify the full pipeline completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)