### PR TITLE
Skip README fetches for repos with no upstream changes

### DIFF
--- a/scripts/scrape_readmes.py
+++ b/scripts/scrape_readmes.py
@@ -104,8 +104,27 @@ def safe_filename(full_name: str, name: str) -> str:
     return f"{owner}+{repo}+{name}"
 
 
-def should_skip(readme_meta) -> bool:
-    """Skip refetch if we recorded a 404 within the TTL window."""
+def should_skip(readme_meta, pushed_at: str | None = None) -> bool:
+    """Return True if this repo's README can be skipped without an API call.
+
+    Two cases:
+    - 404 recorded within the TTL window (repo has no README, don't hammer it).
+    - pushed_at <= fetched_at: the repo hasn't been pushed since we last
+      fetched the README, so it cannot have changed.
+    """
+    if readme_meta and pushed_at and readme_meta.get("fetched_at"):
+        try:
+            last_fetched = datetime.fromisoformat(readme_meta["fetched_at"])
+            last_pushed = datetime.fromisoformat(pushed_at)
+            if last_fetched.tzinfo is None:
+                last_fetched = last_fetched.replace(tzinfo=UTC)
+            if last_pushed.tzinfo is None:
+                last_pushed = last_pushed.replace(tzinfo=UTC)
+            if last_pushed <= last_fetched:
+                return True
+        except ValueError:
+            pass
+
     if not readme_meta or readme_meta.get("status") != "missing":
         return False
     fetched_at = readme_meta.get("fetched_at")
@@ -251,12 +270,15 @@ def process_repos(data, token, readme_dir=README_DIR):
 
     known_paths = collect_known_paths(repositories)
     processed_since_save = 0
+    skipped = 0
 
     for i, full_name in enumerate(full_names, start=1):
         repo = repositories[full_name]
         readme_meta = repo.get("readme")
+        pushed_at = (repo.get("metadata") or {}).get("pushed_at")
 
-        if should_skip(readme_meta):
+        if should_skip(readme_meta, pushed_at):
+            skipped += 1
             continue
 
         etag = readme_meta.get("etag") if readme_meta else None
@@ -331,7 +353,7 @@ def process_repos(data, token, readme_dir=README_DIR):
 
     data["last_updated"] = datetime.now(UTC).isoformat()
     save_data(data)
-    logger.info("README scrape complete.")
+    logger.info(f"README scrape complete. Skipped {skipped}/{total} (pushed_at pre-filter).")
 
 
 def main():

--- a/tests/test_scrape_readmes.py
+++ b/tests/test_scrape_readmes.py
@@ -58,9 +58,26 @@ def test_should_skip_old_missing():
     assert should_skip({"status": "missing", "fetched_at": old}) is False
 
 
-def test_should_skip_ok_never_skips():
+def test_should_skip_ok_without_pushed_at():
     recent = datetime.now(UTC).isoformat()
     assert should_skip({"status": "ok", "fetched_at": recent}) is False
+
+
+def test_should_skip_pushed_before_fetched():
+    fetched = datetime.now(UTC).isoformat()
+    pushed = (datetime.now(UTC) - timedelta(days=2)).isoformat()
+    assert should_skip({"status": "ok", "fetched_at": fetched}, pushed_at=pushed) is True
+
+
+def test_should_skip_pushed_after_fetched():
+    fetched = (datetime.now(UTC) - timedelta(days=2)).isoformat()
+    pushed = datetime.now(UTC).isoformat()
+    assert should_skip({"status": "ok", "fetched_at": fetched}, pushed_at=pushed) is False
+
+
+def test_should_skip_pushed_at_none():
+    fetched = datetime.now(UTC).isoformat()
+    assert should_skip({"status": "ok", "fetched_at": fetched}, pushed_at=None) is False
 
 
 def test_fetch_readme_ok():


### PR DESCRIPTION
## Summary

- Adds a `pushed_at` pre-filter to `should_skip()`: if `metadata.pushed_at <= readme.fetched_at`, the repo hasn't been pushed since the last README fetch — skip it with zero API calls
- Fixes the 40-minute daily GHA runtime caused by ~6729 serial HTTP requests (one per starred repo) even when ETags would return 304
- Logs skip count at completion so the improvement is visible in GHA output
- 3 new tests + renames the now-misleading `test_should_skip_ok_never_skips`

## Test plan

- [ ] All 16 tests pass (`uv run pytest tests/test_scrape_readmes.py`)
- [ ] After merge, trigger `scrape-readmes.yml` manually and confirm runtime drops to under a few minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)